### PR TITLE
Questionnaire Response Validator Modified for Multiple items

### DIFF
--- a/contrib/barcode/src/main/java/com/google/android/fhir/datacapture/contrib/views/barcode/BarCodeReaderViewHolderFactory.kt
+++ b/contrib/barcode/src/main/java/com/google/android/fhir/datacapture/contrib/views/barcode/BarCodeReaderViewHolderFactory.kt
@@ -111,6 +111,9 @@ object BarCodeReaderViewHolderFactory :
       }
 
       override fun setReadOnly(isReadOnly: Boolean) {}
+      override fun addContentDescription() {
+        TODO("Not yet implemented")
+      }
     }
 
   const val WIDGET_EXTENSION = "https://fhir.labs.smartregister.org/barcode-type-widget-extension"

--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/QuestionnaireResponseValidator.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/validation/QuestionnaireResponseValidator.kt
@@ -85,25 +85,23 @@ object QuestionnaireResponseValidator {
     enablementEvaluator: EnablementEvaluator,
     linkIdToValidationResultMap: MutableMap<String, MutableList<ValidationResult>>,
   ): Map<String, List<ValidationResult>> {
-    val questionnaireItemListIterator = questionnaireItemList.iterator()
     val questionnaireResponseItemListIterator = questionnaireResponseItemList.iterator()
 
     while (questionnaireResponseItemListIterator.hasNext()) {
-      val questionnaireResponseItem = questionnaireResponseItemListIterator.next()
-      var questionnaireItem: Questionnaire.QuestionnaireItemComponent?
-      do {
-        require(questionnaireItemListIterator.hasNext()) {
-          "Missing questionnaire item for questionnaire response item ${questionnaireResponseItem.linkId}"
-        }
-        questionnaireItem = questionnaireItemListIterator.next()
-      } while (questionnaireItem!!.linkId != questionnaireResponseItem.linkId)
+      val currentQuestionnaireResponseItem = questionnaireResponseItemListIterator.next()
+      val currentQuestionnaireItem =
+        questionnaireItemList.find { it.linkId == currentQuestionnaireResponseItem.linkId }
+      check(currentQuestionnaireItem != null) {
+        "Missing questionnaire item for questionnaire response item ${currentQuestionnaireResponseItem.linkId}"
+      }
 
-      val enabled = enablementEvaluator.evaluate(questionnaireItem, questionnaireResponseItem)
+      val enabled =
+        enablementEvaluator.evaluate(currentQuestionnaireItem, currentQuestionnaireResponseItem)
 
       if (enabled) {
         validateQuestionnaireResponseItem(
-          questionnaireItem,
-          questionnaireResponseItem,
+          currentQuestionnaireItem,
+          currentQuestionnaireResponseItem,
           context,
           enablementEvaluator,
           linkIdToValidationResultMap,


### PR DESCRIPTION
…ionnaire response items with the same LinkId.

**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[issue number]

**Description**
Modified the Questionnaire Response Validator to validate questionnaire response for multiple items with the same LinkId.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug Fix

**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [ ] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
