### PR TITLE
unpackRepeatedGroups fix.

### DIFF
--- a/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
+++ b/datacapture/src/main/java/com/google/android/fhir/datacapture/extensions/MoreQuestionnaireResponses.kt
@@ -100,22 +100,26 @@ private fun unpackRepeatedGroups(
   questionnaireItem: Questionnaire.QuestionnaireItemComponent,
   questionnaireResponseItem: QuestionnaireResponse.QuestionnaireResponseItemComponent
 ): List<QuestionnaireResponse.QuestionnaireResponseItemComponent> {
-  questionnaireResponseItem.item =
-    unpackRepeatedGroups(questionnaireItem.item, questionnaireResponseItem.item)
-  questionnaireResponseItem.answer.forEach {
-    it.item = unpackRepeatedGroups(questionnaireItem.item, it.item)
-  }
-  return if (questionnaireItem.type == Questionnaire.QuestionnaireItemType.GROUP &&
-      questionnaireItem.repeats
-  ) {
-    questionnaireResponseItem.answer.map {
-      QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-        linkId = questionnaireItem.linkId
-        text = questionnaireItem.localizedTextSpanned?.toString()
-        item = it.item
+  if (questionnaireResponseItem.hasAnswer()) {
+    questionnaireResponseItem.item =
+      unpackRepeatedGroups(questionnaireItem.item, questionnaireResponseItem.item)
+    questionnaireResponseItem.answer.forEach {
+      it.item = unpackRepeatedGroups(questionnaireItem.item, it.item)
+    }
+    return if (questionnaireItem.type == Questionnaire.QuestionnaireItemType.GROUP &&
+        questionnaireItem.repeats
+    ) {
+      questionnaireResponseItem.answer.map {
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          linkId = questionnaireItem.linkId
+          text = questionnaireItem.localizedTextSpanned?.toString()
+          item = it.item
+        }
       }
+    } else {
+      listOf(questionnaireResponseItem)
     }
   } else {
-    listOf(questionnaireResponseItem)
+    return listOf(questionnaireResponseItem)
   }
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #2162

**Description**
The issue was for "unpackrepeatedgroups" when there is only group item in the questionnaire response. If the questionnaire response has only one group item in the questionnaire response then the answer will be empty in the questionnaire response else if the questionnaire response has more than one repeated group then the items will be in the answer. To fix these in the code if the questionnaire response has answer then do the unpacking because then the questionnaire response will have repeated groups else if there is only one group item in the questionnaire response it does not make sense to do the unpack logic.

**Alternative(s) considered**
Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**
Bug Fix/

**Screenshots (if applicable)**

**Checklist**
- [ ] I have read and acknowledged the [Code of conduct](https://github.com/google/android-fhir/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] I have read the [Contributing](https://github.com/google/android-fhir/wiki/Contributing) page.
- [ ] I have signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual), or I am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate ).
- [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the style guide of this project.
- [ ] I have run `./gradlew check` and `./gradlew connectedCheck` to test my changes locally.
- [x] I have built and run the demo app(s) to verify my change fixes the issue and/or does not break the demo app(s).
